### PR TITLE
fix: complete TODO comments for sw and nw label positioning

### DIFF
--- a/source/javascripts/jquery.subwaymap.js
+++ b/source/javascripts/jquery.subwaymap.js
@@ -520,13 +520,12 @@ THE SOFTWARE.
                 pos = "text-align: left; padding-left: " + offset + "px; margin: 0 0 " + offset + "px 0";
                 topOffset = offset * 2;
                 break;
-            case "sw": //TODO
-                pos = "text-align: right; margin:0 " + offset + "px 0 -" + (100 + offset) + "px";
-                topOffset = offset;
+            case "sw":
+                pos = "text-align: right; margin:" + offset + "px " + offset + "px 0 -" + (100 + offset) + "px";
                 break;
-            case "nw": //TODO
-                pos = "text-align: right; margin:0 " + offset + "px 0 -" + (100 + offset) + "px";
-                topOffset = offset;
+            case "nw":
+                pos = "text-align: right; padding-right: " + offset + "px; margin: 0 " + offset + "px " + offset + "px -" + (100 + offset) + "px";
+                topOffset = offset * 2;
                 break;
         }
         var style = (textClass != "" ? "class='" + textClass + "' " : "") + "style='" + (textClass == "" ? "font-size:8pt;font-family:Verdana,Arial,Helvetica,Sans Serif;text-decoration:none;" : "") + "width:100px;" + (pos != "" ? pos : "") + ";position:absolute;top:" + (y + el.offset().top - (topOffset > 0 ? topOffset : 0)) + "px;left:" + (x + el.offset().left) + "px;z-index:3000;'";


### PR DESCRIPTION
## Summary
Implements missing logic for south-west and north-west station label positioning in the subway map. The sw case now includes proper top margin to position labels below the station point, while nw correctly positions labels above with increased topOffset, mirroring the behavior of other directional variants (se, ne, etc).

## Changes
- Removed TODO comments from sw and nw cases in jquery.subwaymap.js
- Fixed sw positioning to include top margin and remove incorrect topOffset
- Fixed nw positioning to include bottom margin, padding-right, and proper topOffset = offset * 2

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI layout change affecting only station label placement for `sw`/`nw` directions.
> 
> **Overview**
> Fixes missing/incorrect `sw` and `nw` station label positioning in `jquery.subwaymap.js`.
> 
> Updates the computed CSS for these label directions: `sw` now applies a top margin offset (and no longer tweaks `topOffset`), while `nw` adds `padding-right`, adjusts margins, and sets `topOffset = offset * 2` to align with other “north” variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 295b14a047c71d5d2de6d399ea73831dd5641288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->